### PR TITLE
Add conversions to a different base, fixes #17, fixes #18

### DIFF
--- a/src/Data/Int.js
+++ b/src/Data/Int.js
@@ -15,12 +15,34 @@ exports.toNumber = function (n) {
   return n;
 };
 
-exports.fromStringImpl = function (just) {
+exports.fromStringAsImpl = function (just) {
   return function (nothing) {
-    return function (s) {
-      /* jshint bitwise: false */
-      var i = parseFloat(s);
-      return (i | 0) === i ? just(i) : nothing;
+    return function (radix) {
+      var digits;
+      if (radix < 11) {
+        digits = "[0-" + (radix - 1).toString() + "]";
+      } else if (radix === 11) {
+        digits = "[0-9a]";
+      } else {
+        digits = "[0-9a-" + String.fromCharCode(86 + radix) + "]";
+      }
+      var pattern = new RegExp("^[\\+\\-]?" + digits + "+$", "i");
+
+      return function (s) {
+        /* jshint bitwise: false */
+        if (pattern.test(s)) {
+          var i = parseInt(s, radix);
+          return (i | 0) === i ? just(i) : nothing;
+        } else {
+          return nothing;
+        }
+      };
     };
+  };
+};
+
+exports.toStringAs = function (radix) {
+  return function (i) {
+    return i.toString(radix);
   };
 };

--- a/src/Data/Int.purs
+++ b/src/Data/Int.purs
@@ -5,11 +5,20 @@ module Data.Int
   , round
   , toNumber
   , fromString
+  , Radix()
+  , radix
+  , binary
+  , octal
+  , decimal
+  , hexadecimal
+  , fromStringAs
+  , toStringAs
   , even
   , odd
   ) where
 
 import Data.Boolean (otherwise)
+import Data.BooleanAlgebra ((&&))
 import Data.Bounded (top, bottom)
 import Data.Eq ((==), (/=))
 import Data.Function ((<<<))
@@ -65,13 +74,7 @@ foreign import toNumber :: Int -> Number
 -- | and fall within the valid range of values for the `Int` type, otherwise
 -- | `Nothing` is returned.
 fromString :: String -> Maybe Int
-fromString = fromStringImpl Just Nothing
-
-foreign import fromStringImpl
-  :: (forall a. a -> Maybe a)
-  -> (forall a. Maybe a)
-  -> String
-  -> Maybe Int
+fromString = fromStringAs (Radix 10)
 
 -- | Returns whether an `Int` is an even number.
 -- |
@@ -90,3 +93,47 @@ even x = x .&. 1 == 0
 -- | ```
 odd :: Int -> Boolean
 odd x = x .&. 1 /= 0
+
+-- | The number of unique digits (including zero) used to represent integers in
+-- | a specific base.
+newtype Radix = Radix Int
+
+-- | The base-2 system.
+binary :: Radix
+binary = Radix 2
+
+-- | The base-8 system.
+octal :: Radix
+octal = Radix 8
+
+-- | The base-10 system.
+decimal :: Radix
+decimal = Radix 10
+
+-- | The base-16 system.
+hexadecimal :: Radix
+hexadecimal = Radix 16
+
+-- | Create a `Radix` from a number between 2 and 36.
+radix :: Int -> Maybe Radix
+radix n | n >= 2 && n <= 36 = Just (Radix n)
+        | otherwise         = Nothing
+
+-- | Like `fromString`, but the integer can be specified in a different base.
+-- |
+-- | Example:
+-- | ``` purs
+-- | fromStringAs binary      "100" == Just 4
+-- | fromStringAs hexadecimal "ff"  == Just 255
+-- | ```
+fromStringAs :: Radix -> String -> Maybe Int
+fromStringAs = fromStringAsImpl Just Nothing
+
+foreign import fromStringAsImpl
+  :: (forall a. a -> Maybe a)
+  -> (forall a. Maybe a)
+  -> Radix
+  -> String
+  -> Maybe Int
+
+foreign import toStringAs :: Radix -> Int -> String


### PR DESCRIPTION
Apart from the fact that the FFI code is incredibly ugly, this looks like a solid approach to me. I'm happy to change all aspects of this, though (some people might dislike the Regex approach).

This fixes the parsing problems mentioned in #18 and adds new functionality `fromStringAs` and `toStringAs`, which can be used like this:
``` purs
> fromStringAs binary "1000"
Just (8)

> fromStringAs binary "2" -- wrong digit!
Nothing

> fromStringAs hexadecimal "ff0000"
Just (16711680)

> toStringAs hexadecimal 255
"ff"
```