### PR TITLE
Don't rely on inlining of Ord Number in unsafeClamp

### DIFF
--- a/src/Data/Int.purs
+++ b/src/Data/Int.purs
@@ -27,7 +27,7 @@ import Prelude
 
 import Data.Int.Bits ((.&.))
 import Data.Maybe (Maybe(..), fromMaybe)
-import Global (infinity)
+import Global (isFinite)
 
 import Math as Math
 
@@ -65,8 +65,7 @@ round = unsafeClamp <<< Math.round
 -- | This function will return 0 if the input is `NaN` or an `Infinity`.
 unsafeClamp :: Number -> Int
 unsafeClamp x
-  | x == infinity = 0
-  | x == -infinity = 0
+  | not (isFinite x) = 0
   | x >= toNumber top = top
   | x <= toNumber bottom = bottom
   | otherwise = fromMaybe 0 (fromNumber x)

--- a/test/Test/Data/Int.purs
+++ b/test/Test/Data/Int.purs
@@ -56,6 +56,7 @@ testInt = do
   let testNonNumber f = do
         assert $ f nan == 0
         assert $ f infinity == 0
+        assert $ f (-infinity) == 0
 
   testNonNumber round
   testNonNumber ceil


### PR DESCRIPTION
Fixes #34. I've also added a test that the rounding functions behave correctly with negative infinity.