### PR TITLE
Add safe integers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Notable changes to this project are documented in this file. The format is based
 Breaking changes:
 
 New features:
+- Added `maxSafeInteger`, `minSafeInteger`, `isSafeInteger` (#48 by @toastal)
 
 Bugfixes:
 

--- a/src/Data/Int.js
+++ b/src/Data/Int.js
@@ -65,3 +65,9 @@ exports.pow = function (x) {
     return Math.pow(x,y) | 0;
   };
 };
+
+exports.maxSafeInteger = Number.MAX_SAFE_INTEGER;
+
+exports.minSafeInteger = Number.MIN_SAFE_INTEGER;
+
+exports.isSafeInteger = Number.isSafeInteger;

--- a/src/Data/Int.purs
+++ b/src/Data/Int.purs
@@ -249,3 +249,9 @@ foreign import fromStringAsImpl
   -> Maybe Int
 
 foreign import toStringAs :: Radix -> Int -> String
+
+foreign import maxSafeInteger :: Number
+
+foreign import minSafeInteger :: Number
+
+foreign import isSafeInteger :: Number -> Boolean


### PR DESCRIPTION
**Description of the change**

https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.issafeinteger

Add `maxSafeInteger`, `minSafeInteger`, and `isSafeInteger`.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
