### PR TITLE
Migrate functions from `Math`; drop `Math` as dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+- Drop dependency on deprecated `math` package (#51 by @JordanMartinez)
 
 ## [v5.0.0](https://github.com/purescript/purescript-integers/releases/tag/v5.0.0) - 2021-02-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Notable changes to this project are documented in this file. The format is based
 
 Breaking changes:
 - Migrate FFI to ES modules (#50 by @kl0tl and @JordanMartinez)
+- Migrate `trunc` from `math` package (#51 by @JordanMartinez)
 
 New features:
 

--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,6 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-math": "master",
     "purescript-maybe": "master",
     "purescript-numbers": "master",
     "purescript-prelude": "master"

--- a/src/Data/Int.js
+++ b/src/Data/Int.js
@@ -63,7 +63,3 @@ export const pow = function (x) {
     return Math.pow(x,y) | 0;
   };
 };
-
-export const trunc = Math.trunc || function (n) {
-  return n < 0 ? Math.ceil(n) : Math.floor(n);
-};

--- a/src/Data/Int.js
+++ b/src/Data/Int.js
@@ -63,3 +63,7 @@ export const pow = function (x) {
     return Math.pow(x,y) | 0;
   };
 };
+
+export const trunc = Math.trunc || function (n) {
+  return n < 0 ? Math.ceil(n) : Math.floor(n);
+};

--- a/src/Data/Int.purs
+++ b/src/Data/Int.purs
@@ -242,9 +242,11 @@ foreign import rem :: Int -> Int -> Int
 -- | Raise an Int to the power of another Int.
 foreign import pow :: Int -> Int -> Int
 
--- | Truncates the decimal portion of a number. Equivalent to `floor` if the
--- | number is positive, and `ceil` if the number is negative.
-foreign import trunc :: Number -> Int
+-- | Convert a `Number` to an `Int`, by dropping the decimal.
+-- | Values outside the `Int` range are clamped, `NaN` and `Infinity`
+-- | values return 0.
+trunc :: Number -> Int
+trunc = unsafeClamp <<< Number.trunc
 
 foreign import fromStringAsImpl
   :: (forall a. a -> Maybe a)

--- a/src/Data/Int.purs
+++ b/src/Data/Int.purs
@@ -29,8 +29,7 @@ import Prelude
 import Data.Int.Bits ((.&.))
 import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Number (isFinite)
-
-import Math as Math
+import Data.Number as Number
 
 -- | Creates an `Int` from a `Number` value. The number must already be an
 -- | integer and fall within the valid range of values for the `Int` type
@@ -48,13 +47,13 @@ foreign import fromNumberImpl
 -- | less than the argument. Values outside the `Int` range are clamped, `NaN`
 -- | and `Infinity` values return 0.
 floor :: Number -> Int
-floor = unsafeClamp <<< Math.floor
+floor = unsafeClamp <<< Number.floor
 
 -- | Convert a `Number` to an `Int`, by taking the closest integer equal to or
 -- | greater than the argument. Values outside the `Int` range are clamped,
 -- | `NaN` and `Infinity` values return 0.
 ceil :: Number -> Int
-ceil = unsafeClamp <<< Math.ceil
+ceil = unsafeClamp <<< Number.ceil
 
 -- | Convert a `Number` to an `Int`, by dropping the decimal.
 -- | Values outside the `Int` range are clamped, `NaN` and `Infinity`
@@ -66,7 +65,7 @@ trunc = unsafeClamp <<< Number.trunc
 -- | argument. Values outside the `Int` range are clamped, `NaN` and `Infinity`
 -- | values return 0.
 round :: Number -> Int
-round = unsafeClamp <<< Math.round
+round = unsafeClamp <<< Number.round
 
 -- | Convert an integral `Number` to an `Int`, by clamping to the `Int` range.
 -- | This function will return 0 if the input is `NaN` or an `Infinity`.

--- a/src/Data/Int.purs
+++ b/src/Data/Int.purs
@@ -2,6 +2,7 @@ module Data.Int
   ( fromNumber
   , ceil
   , floor
+  , trunc
   , round
   , toNumber
   , fromString
@@ -21,7 +22,6 @@ module Data.Int
   , quot
   , rem
   , pow
-  , trunc
   ) where
 
 import Prelude
@@ -55,6 +55,12 @@ floor = unsafeClamp <<< Math.floor
 -- | `NaN` and `Infinity` values return 0.
 ceil :: Number -> Int
 ceil = unsafeClamp <<< Math.ceil
+
+-- | Convert a `Number` to an `Int`, by dropping the decimal.
+-- | Values outside the `Int` range are clamped, `NaN` and `Infinity`
+-- | values return 0.
+trunc :: Number -> Int
+trunc = unsafeClamp <<< Number.trunc
 
 -- | Convert a `Number` to an `Int`, by taking the nearest integer to the
 -- | argument. Values outside the `Int` range are clamped, `NaN` and `Infinity`
@@ -241,12 +247,6 @@ foreign import rem :: Int -> Int -> Int
 
 -- | Raise an Int to the power of another Int.
 foreign import pow :: Int -> Int -> Int
-
--- | Convert a `Number` to an `Int`, by dropping the decimal.
--- | Values outside the `Int` range are clamped, `NaN` and `Infinity`
--- | values return 0.
-trunc :: Number -> Int
-trunc = unsafeClamp <<< Number.trunc
 
 foreign import fromStringAsImpl
   :: (forall a. a -> Maybe a)

--- a/src/Data/Int.purs
+++ b/src/Data/Int.purs
@@ -21,6 +21,7 @@ module Data.Int
   , quot
   , rem
   , pow
+  , trunc
   ) where
 
 import Prelude
@@ -240,6 +241,10 @@ foreign import rem :: Int -> Int -> Int
 
 -- | Raise an Int to the power of another Int.
 foreign import pow :: Int -> Int -> Int
+
+-- | Truncates the decimal portion of a number. Equivalent to `floor` if the
+-- | number is positive, and `ceil` if the number is negative.
+foreign import trunc :: Number -> Int
 
 foreign import fromStringAsImpl
   :: (forall a. a -> Maybe a)

--- a/test/Test/Data/Int.purs
+++ b/test/Test/Data/Int.purs
@@ -155,7 +155,6 @@ testInt = do
         let
           q = quot a b
           r = rem a b
-          msg = show a <> " / " <> show b <> ": "
         in do
           assert $ q * b + r == a
     -- Check when dividend goes into divisor exactly


### PR DESCRIPTION
**Description of the change**

Part of https://github.com/purescript/purescript-math/issues/31#issuecomment-1078569316

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
