### PR TITLE
Specific integers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Notable changes to this project are documented in this file. The format is based
 Breaking changes:
 
 New features:
+- Added `minInt` and `maxInt` (#54 by @JamieBallingall)
 
 Bugfixes:
 

--- a/src/Data/Int.purs
+++ b/src/Data/Int.purs
@@ -1,3 +1,5 @@
+-- | Functions for working with PureScript's builtin `Int` type. A `Int`
+-- | is a signeed 32-bit integer.
 module Data.Int
   ( fromNumber
   , ceil
@@ -30,6 +32,25 @@ import Data.Int.Bits ((.&.))
 import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Number (isFinite)
 import Data.Number as Number
+
+-- | The most negative `Int`, equal to -2^31.
+-- | ```purs
+-- | > minInt
+-- | -2147483648
+-- | ```
+minInt :: Int
+minInt = -0x80000000
+
+-- | The most positive `Int`, equal to 2^31 - 1.
+-- | ```purs
+-- | > maxInt
+-- | 2147483647
+-- |
+-- | > maxInt + 1 == minInt
+-- | true
+-- | ```
+maxInt :: Int
+maxInt = 0x7FFFFFFF
 
 -- | Creates an `Int` from a `Number` value. The number must already be an
 -- | integer and fall within the valid range of values for the `Int` type

--- a/src/Data/Int.purs
+++ b/src/Data/Int.purs
@@ -1,7 +1,9 @@
 -- | Functions for working with PureScript's builtin `Int` type. A `Int`
 -- | is a signeed 32-bit integer.
 module Data.Int
-  ( fromNumber
+  ( minInt
+  , maxInt
+  , fromNumber
   , ceil
   , floor
   , trunc

--- a/test/Test/Data/Int.purs
+++ b/test/Test/Data/Int.purs
@@ -2,7 +2,7 @@ module Test.Data.Int (testInt) where
 
 import Prelude
 
-import Data.Int (binary, ceil, even, floor, fromNumber, fromString, fromStringAs, hexadecimal, octal, odd, parity, pow, quot, radix, rem, round, toNumber, toStringAs)
+import Data.Int (binary, ceil, even, floor, fromNumber, fromString, fromStringAs, hexadecimal, maxInt, minInt, octal, odd, parity, pow, quot, radix, rem, round, toNumber, toStringAs)
 import Data.Maybe (Maybe(..), fromJust)
 import Effect (Effect)
 import Effect.Console (log)
@@ -12,6 +12,15 @@ import Test.Assert (assert)
 
 testInt :: Effect Unit
 testInt = do
+
+  log "minInt should be -2147483648"
+  assert $ minInt == -2147483648
+
+  log "maxInt should be 2147483647"
+  assert $ maxInt == 2147483647
+
+  log "maxInt + 1 should equal minInt"
+  assert $ maxInt + 1 == minInt
 
   log "fromNumber should coerce integer values"
   assert $ fromNumber 1.0 == Just 1


### PR DESCRIPTION
Add two constant values: minInt and maxInt. Similar in spirit to PR #48 but provides the bounds on 32-bit signed integers (i.e., the `Int` type) as `Int` rather than referencing Javascript's concept of minimum and maximum integers.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [X] Linked any existing issues or proposals that this pull request should close
- [X] Updated or added relevant documentation
- [X] Added a test for the contribution (if applicable)
